### PR TITLE
Add missing epub:type for endnotes

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -9,82 +9,82 @@
 		<section id="endnotes" epub:type="endnotes">
 			<h2 epub:type="title">Endnotes</h2>
 			<ol>
-				<li id="note-1">
+				<li id="note-1" epub:type="endnote">
 					<p>The Lezghins are among the medley of mountain tribes living in Daghestan and part of the Terek province. These mountaineers of the Eastern Caucasus are nearly all Sun’i Mohammedans. <a href="chapter-1.xhtml#noteref-1" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-2">
+				<li id="note-2" epub:type="endnote">
 					<p>One of Russia’s bravest and greatest generals in the war with Napoleon, 1812. <a href="chapter-1.xhtml#noteref-2" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-3">
+				<li id="note-3" epub:type="endnote">
 					<p>Roman Catholic priests are so called in Lithuania and Poland. <a href="chapter-3.xhtml#noteref-3" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-4">
+				<li id="note-4" epub:type="endnote">
 					<p><dfn xml:lang="ru">Schtoss</dfn> is a sort of Russian hazard. <a href="chapter-3.xhtml#noteref-4" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-5">
+				<li id="note-5" epub:type="endnote">
 					<p>Yuri = George. <a href="chapter-4.xhtml#noteref-5" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-6">
+				<li id="note-6" epub:type="endnote">
 					<p><dfn xml:lang="ru">Roubashka</dfn> (blouse). <a href="chapter-5.xhtml#noteref-6" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-7">
+				<li id="note-7" epub:type="endnote">
 					<p>The official newspaper of the Russian Army. <a href="chapter-6.xhtml#noteref-7" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-8">
+				<li id="note-8" epub:type="endnote">
 					<p>Professional floor-polisher. <a href="chapter-6.xhtml#noteref-8" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-9">
+				<li id="note-9" epub:type="endnote">
 					<p>A town and “government” in East Russia. <a href="chapter-7.xhtml#noteref-9" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-10">
+				<li id="note-10" epub:type="endnote">
 					<p>Corresponds to the Swedish smörgåsbord, and consists of a number of cold dishes and delicacies. <a href="chapter-7.xhtml#noteref-10" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-11">
+				<li id="note-11" epub:type="endnote">
 					<p>A national dish in Russia, consisting of a sort of buckwheat porridge baked in the oven in fireproof earthen vessels, which are put on the table. <a href="chapter-7.xhtml#noteref-11" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-12">
+				<li id="note-12" epub:type="endnote">
 					<p>In the time of Nicholas, sons of soldiers quartered or garrisoned in certain districts. They were liable to be called on to serve. <a href="chapter-7.xhtml#noteref-12" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-13">
+				<li id="note-13" epub:type="endnote">
 					<p>An old Slavonic character (l’schiza), only occurring in the Russian Bible and Ritual. <a href="chapter-8.xhtml#noteref-13" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-14">
+				<li id="note-14" epub:type="endnote">
 					<p>Nickname for Little Russians on account of their curious habit of cutting and fashioning their hair into a tuft (<i xml:lang="ru">khokhol</i>) on the crown. <a href="chapter-9.xhtml#noteref-14" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-15">
+				<li id="note-15" epub:type="endnote">
 					<p>An affectionate diminutive of George. <a href="chapter-9.xhtml#noteref-15" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-16">
+				<li id="note-16" epub:type="endnote">
 					<p>Sliva is the Russian for plum. <a href="chapter-10.xhtml#noteref-16" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-17">
+				<li id="note-17" epub:type="endnote">
 					<p>Arshin = 2.33 feet. <a href="chapter-11.xhtml#noteref-17" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-18">
+				<li id="note-18" epub:type="endnote">
 					<p>Pet name for Alexandra. <a href="chapter-13.xhtml#noteref-18" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-19">
+				<li id="note-19" epub:type="endnote">
 					<p>A light jacket worn in the hot weather. <a href="chapter-14.xhtml#noteref-19" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-20">
+				<li id="note-20" epub:type="endnote">
 					<p>The name given to Ivan the Terrible’s lifeguards and executioners. <a href="chapter-18.xhtml#noteref-20" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-21">
+				<li id="note-21" epub:type="endnote">
 					<p><dfn xml:lang="ru">Chinóvnik</dfn>, Russian word for official. <a href="chapter-21.xhtml#noteref-21" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-22">
+				<li id="note-22" epub:type="endnote">
 					<p>Ivan Milostivni, one of the innumerable saints of the Greek Church. <a href="chapter-21.xhtml#noteref-22" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-23">
+				<li id="note-23" epub:type="endnote">
 					<p>The allusion is to the double eagle in the arms of Russia. <a href="chapter-21.xhtml#noteref-23" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-24">
+				<li id="note-24" epub:type="endnote">
 					<p><dfn xml:lang="ru">Vobla</dfn> is a kind of fish of the size of Prussian carp, and is caught in the Volga. <a href="chapter-21.xhtml#noteref-24" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-25">
+				<li id="note-25" epub:type="endnote">
 					<p>Au revoir. <a href="chapter-21.xhtml#noteref-25" epub:type="backlink">↩</a></p>
 				</li>
-				<li id="note-26">
+				<li id="note-26" epub:type="endnote">
 					<p>Untranslatable pun on the two last syllables of <i xml:lang="ru">svidánia</i>; <i xml:lang="ru">Dania</i> means Denmark, <i xml:lang="ru">Schvezia</i>, Sweden. <a href="chapter-21.xhtml#noteref-26" epub:type="backlink">↩</a></p>
 				</li>
 			</ol>


### PR DESCRIPTION
Sorry, not sure how I missed this. I’ve double-checked the rest of the corpus and this is the only project of mine missing them.