### PR TITLE
Drop Roman numeral semantics

### DIFF
--- a/src/epub/text/chapter-8.xhtml
+++ b/src/epub/text/chapter-8.xhtml
@@ -24,7 +24,7 @@
 			<p>“This is what I want you to do for me,” Lieschtschenko went on in the same humble voice. “For God’s sake see that she does not have to sit out many dances.”</p>
 			<p>“Maria Viktorovna?”</p>
 			<p>“Yes, please⁠—”</p>
-			<p>“Double with the yellow in the corner,” said Biek-Agamalov, indicating the stroke he intended to make. Being short, he often found billiards very troublesome. To reach the ball now he was obliged to lie lengthways on the table. He became quite red in the face through the effort, and two veins in his forehead swelled to such an extent that they converged at the top of his nose like the letter <span epub:type="z3998:roman">V</span>.<a href="endnotes.xhtml#note-13" id="noteref-13" epub:type="noteref">13</a></p>
+			<p>“Double with the yellow in the corner,” said Biek-Agamalov, indicating the stroke he intended to make. Being short, he often found billiards very troublesome. To reach the ball now he was obliged to lie lengthways on the table. He became quite red in the face through the effort, and two veins in his forehead swelled to such an extent that they converged at the top of his nose like the letter V.<a href="endnotes.xhtml#note-13" id="noteref-13" epub:type="noteref">13</a></p>
 			<p>“What a conjurer!” said Olisár in a jeering, ironical tone. “I could not do that.”</p>
 			<p>Agamalov’s cue touched the ball with a dry, scraping sound. The ball did not move from its place.</p>
 			<p>“Miss!” cried Olisár jubilantly, as he danced a cancan round the billiard table. “Do you snore when you sleep, my pretty creature?”</p>


### PR DESCRIPTION
Identical to an example from [the manual](https://standardebooks.org/manual/1.0.0/8-typography#8.2.7.2).